### PR TITLE
add question n to tally_and_perc function

### DIFF
--- a/joint-carpentry-projects/long-term-survey/report.rmd
+++ b/joint-carpentry-projects/long-term-survey/report.rmd
@@ -102,7 +102,8 @@ Recommended <- round(prop.table(table(data$Recommended))* 100)
 Recommended
 
 # Function that makes a table of counts and percentages
-tally_and_perc <- function(df, colname, na.rm = FALSE){
+# question_n is set by default to the number of respondents in the survey - 476. This value may have to be set by question. 
+tally_and_perc <- function(df, colname, na.rm = FALSE, question_n = 476){
   quo_colname <- enquo(colname)
 
   df %>% 
@@ -111,7 +112,7 @@ tally_and_perc <- function(df, colname, na.rm = FALSE){
     filter(if_else(rep(na.rm, nrow(.)),
                   !is.na(!!quo_colname),
                   as.logical(rep(1, nrow(.))))) %>% 
-    mutate(`%` = round(n / sum(n) * 100, 1)) 
+    mutate(`%` = round(n / question_n * 100, 1)) 
 }
 ```
 # Highlights
@@ -773,6 +774,7 @@ ggsave("figures/workshop_impact_heatmap.png")
 # Code for behaviors adopted
 # Responses are in columns 'Behaviors-Adopted' through 'Column32'
 # Use 'gather' to go from wide to long format
+
 Behaviors <- 
 data %>%
   select(`Behaviors-Adopted`:Column32) %>% 


### PR DESCRIPTION
Hi Kari, 

Hope this done more good then harm, please check carefully! 
I see you have a function that calculates the percentage for different questions. Right now, you seem to be summing all the respondents in a question column. But for example in #14 a person could answer more than once (inflating your n). Your n should be everyone who saw the question (e.g. 476?) but may be smaller if you had survey branching. I put the default argument (question_n = 476) into your `tally_and_perc` function. If question n is different, you can pass that parameter in where that function is used along with your value for n. Maybe check to see this does not break other things. I didn't see a problem when I looked briefly. 